### PR TITLE
Fix for not able to access key cloak admin console

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   keycloak:
     container_name: idp-keycloak
-    image: jboss/keycloak:15.1.0
+    image: wizzn/keycloak:14
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: postgres


### PR DESCRIPTION
- Resolves the issue of running keycloak from a docker container . The jboss/Keykoak has issues running pulling the image from https://hub.docker.com/r/wizzn/keycloak/tags works .
- Able to access admin console via local host

